### PR TITLE
feat(sound playback): allow simultaneous playback

### DIFF
--- a/backend/src/discord/client.rs
+++ b/backend/src/discord/client.rs
@@ -128,7 +128,7 @@ impl Client {
             ClientError::DecodingError(why)
         })?;
 
-        call.play_only_source(source);
+        call.play_source(source);
         Ok(())
     }
 


### PR DESCRIPTION
Implements the simultaneous playback feature requested in #6

I'm not sure, if there should be some form of rate limit built in to prevent spamming long playing sounds and maybe overload the server. I guess in small friendgroups/servers this shouldn't be too much of a problem. Also, there always is the stop button to abort all sounds.