### PR TITLE
feat(frontend: soundboard): adjust sound button sizes to improve UX

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -2,4 +2,6 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  max-width: 100vw;
+  overflow-x: hidden;
 }

--- a/frontend/src/app/keybind-generator/keybind-generator.component.scss
+++ b/frontend/src/app/keybind-generator/keybind-generator.component.scss
@@ -1,7 +1,7 @@
 @import 'variables';
 
 .max-width {
-  max-width: 1200px;
+  max-width: 1500px;
   margin: 0 auto;
   width: 100%;
 }

--- a/frontend/src/app/recorder/recorder.component.scss
+++ b/frontend/src/app/recorder/recorder.component.scss
@@ -7,7 +7,7 @@
 }
 
 .max-width {
-  max-width: 1200px;
+  max-width: 1500px;
   margin: 0 auto;
   width: 100%;
 }

--- a/frontend/src/app/settings/random-infixes/random-infixes.component.scss
+++ b/frontend/src/app/settings/random-infixes/random-infixes.component.scss
@@ -1,6 +1,6 @@
 mat-card {
   margin-bottom: 8px;
-  max-width: 1200px;
+  max-width: 1500px;
 }
 
 .infix-list-item {

--- a/frontend/src/app/soundboard/soundboard-button/soundboard-button.component.html
+++ b/frontend/src/app/soundboard/soundboard-button/soundboard-button.component.html
@@ -1,5 +1,5 @@
 <button mat-raised-button (click)="this.playSound()" class="main-button">
-  <div class="sound-name"><ng-content></ng-content></div>
+  <div class="sound-name" #soundName><ng-content></ng-content></div>
   <div class="sound-source mat-small" [matTooltip]="(guildId | guildName) + displayedCategory" matTooltipShowDelay="500">
     <ng-container *ngIf="category == null">{{ guildId | guildName }}</ng-container>
     <ng-container *ngIf="category === ''"><span class="no-category">-- empty --</span></ng-container>

--- a/frontend/src/app/soundboard/soundboard-button/soundboard-button.component.scss
+++ b/frontend/src/app/soundboard/soundboard-button/soundboard-button.component.scss
@@ -4,10 +4,11 @@
 
 .main-button {
   height: 100%;
-  width: 100%;
+  min-width: 100%;
+  object-fit: cover;
 
   &:not(:only-child) {
-    padding-right: 56px;
+    padding-right: 72px;
   }
 
   ::ng-deep .mdc-button__label {
@@ -15,6 +16,7 @@
     align-self: stretch;
     flex-direction: column;
     text-align: center;
+    min-width: 100%;
 
     z-index: 0; // prevents the label from overlapping the preview button or filters
   }
@@ -25,6 +27,10 @@
   right: 16px;
   top: 50%;
   transform: translateY(-50%);
+
+  &.mat-unthemed {
+    color: rgba(232, 230, 227, 0.38);
+  }
 }
 
 .sound-name,
@@ -38,7 +44,15 @@
   align-items: center;
   justify-content: center;
   font-weight: 500;
-  padding-bottom: 1em;
+  margin-top: 0.5em;
+  margin-bottom: 1.5em;
+  max-height: 100%;
+  word-break: break-word;
+
+  ::ng-deep .mat-icon {
+    flex: none;
+    margin-right: 0.5em;
+  }
 }
 
 .sound-source {

--- a/frontend/src/app/soundboard/soundboard-button/soundboard-button.component.ts
+++ b/frontend/src/app/soundboard/soundboard-button/soundboard-button.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'app-soundboard-button',
@@ -6,7 +6,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
   styleUrls: ['./soundboard-button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SoundboardButtonComponent {
+export class SoundboardButtonComponent implements AfterViewInit {
   @Input({ required: true }) guildId: string;
   @Input() category?: string;
   @Input() isLocallyPlaying = false;
@@ -15,8 +15,14 @@ export class SoundboardButtonComponent {
   @Output() playLocal = new EventEmitter<void>();
   @Output() stopLocal = new EventEmitter<void>();
 
+  @ViewChild('soundName') nameLabel: ElementRef;
+
   get displayedCategory() {
     return this.category == null || this.category === '' ? '' : `/${this.category}`;
+  }
+
+  ngAfterViewInit() {
+    this.setLabelMinWidthToFitContent();
   }
 
   playSound(local = false) {
@@ -33,5 +39,19 @@ export class SoundboardButtonComponent {
     } else {
       this.playSound(true);
     }
+  }
+
+  setLabelMinWidthToFitContent() {
+    const label = this.nameLabel.nativeElement;
+    label.style.whiteSpace = 'nowrap';
+    const computedStyle = window.getComputedStyle(label);
+    const horizontalPadding = parseFloat(computedStyle.paddingLeft) + parseFloat(computedStyle.paddingRight);
+    const singleLineWidth = label.clientWidth - horizontalPadding;
+
+    // subtract all paddings/margins from viewport width; this gets the maximum width, the label can have
+    const cssMaxWidth = 'calc(100vw - 72px - 16px - 16px - 10px)';
+
+    label.style.minWidth = `min(${singleLineWidth / 2 + horizontalPadding + 50}px, ${cssMaxWidth})`;
+    label.style.whiteSpace = null;
   }
 }

--- a/frontend/src/app/soundboard/soundboard.component.scss
+++ b/frontend/src/app/soundboard/soundboard.component.scss
@@ -4,7 +4,7 @@
   flex-direction: column;
 }
 
-$main-width: 1200px;
+$main-width: 1500px;
 
 .max-width {
   margin: 0 auto;
@@ -95,9 +95,8 @@ main {
 
     app-soundboard-button {
       margin: 5px;
-      flex: 1 0 175px;
-      max-width: 300px;
-      height: 70px;
+      flex: 1 0 170px;
+      min-height: 70px;
     }
   }
 


### PR DESCRIPTION
After upgrading my "live" soundboard to the latest `development` version, I found the visuals of many sounds together with long names pretty unpleasent. Also the local playback buttons are too bright and eyecatchy for my taste.

I tried adjusting the button sizes a bit to better fit their content (and don't allow more than two lines for the label). They now expand horizontally to allow the text to span two lines (this is approximated). In extreme cases vertical expansion is also possible, but I only got this with one singe really long word. 
Unfortunately, I was not able to find a pure CSS solution and had to hook some JS into the component rendering. I also increased the maximum content width a bit and dimmed down the local playback buttons.

## Desktop

### before

![soundboard gamingstuebchen de_ (2)](https://github.com/dominikks/discord-soundboard-bot/assets/34233066/911aa643-14eb-4347-93fa-7d6c5cf3558a)

### after

![localhost_4200_ (3)](https://github.com/dominikks/discord-soundboard-bot/assets/34233066/9e1babca-137c-42d3-910d-47cbecaf7442)

## Mobile

<details>

<summary>before</summary>

![soundboard gamingstuebchen de_ (4)](https://github.com/dominikks/discord-soundboard-bot/assets/34233066/36379eb7-1e3a-4ec5-9676-940bb44bfbe4)

</details>

<details>

<summary>after</summary>

![localhost_4200_ (4)](https://github.com/dominikks/discord-soundboard-bot/assets/34233066/fe1c159b-94ed-4ff4-9275-d1b33f0be88f)

</details>