### PR TITLE
Make auth tokens persistent (#9)

### DIFF
--- a/backend/src/api/sounds.rs
+++ b/backend/src/api/sounds.rs
@@ -1,14 +1,8 @@
-use crate::api::auth::UserId;
-use crate::api::Snowflake;
-use crate::audio_utils;
-use crate::db::models;
-use crate::db::DbConn;
-use crate::discord::management::check_guild_moderator;
-use crate::discord::management::check_guild_user;
-use crate::discord::management::get_guilds_for_user;
-use crate::discord::management::PermissionError;
-use crate::file_handling;
-use crate::CacheHttp;
+use std::convert::TryFrom;
+use std::num::TryFromIntError;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
 use bigdecimal::BigDecimal;
 use bigdecimal::FromPrimitive;
 use bigdecimal::ToPrimitive;
@@ -26,11 +20,19 @@ use serde::Serialize;
 use serde_with::serde_as;
 use serde_with::TimestampSeconds;
 use serenity::model::id::GuildId;
-use std::convert::TryFrom;
-use std::num::TryFromIntError;
-use std::path::PathBuf;
-use std::time::SystemTime;
 use tokio::fs;
+
+use crate::api::auth::UserId;
+use crate::api::Snowflake;
+use crate::audio_utils;
+use crate::db::models;
+use crate::db::DbConn;
+use crate::discord::management::check_guild_moderator;
+use crate::discord::management::check_guild_user;
+use crate::discord::management::get_guilds_for_user;
+use crate::discord::management::PermissionError;
+use crate::file_handling;
+use crate::CacheHttp;
 
 pub fn get_routes() -> Vec<Route> {
     routes![
@@ -114,7 +116,7 @@ struct Sound {
     #[serde_as(as = "TimestampSeconds<String>")]
     created_at: SystemTime,
     volume_adjustment: Option<f32>,
-    soundfile: Option<Soundfile>,
+    sound_file: Option<Soundfile>,
 }
 
 #[serde_as]
@@ -144,7 +146,7 @@ impl TryFrom<(models::Sound, Option<models::Soundfile>)> for Sound {
             category: s.category,
             created_at: s.created_at,
             volume_adjustment: s.volume_adjustment,
-            soundfile: f.map(|f| Soundfile {
+            sound_file: f.map(|f| Soundfile {
                 max_volume: f.max_volume,
                 mean_volume: f.mean_volume,
                 length: f.length,

--- a/frontend/src/app/keybind-generator/keybind-generator.component.html
+++ b/frontend/src/app/keybind-generator/keybind-generator.component.html
@@ -14,9 +14,19 @@
     automatically play sounds when a key combination on your computer is pressed.</p
   >
   <p
-    >The generated script contains a personal auth token for your account. Do not share it with others. It expires after a week, at which
-    point you will have to re-download the AutoHotkey script.</p
+    >The generated script contains a personal auth token for your account. Do not share it with others. You can regenerate it manually,
+    making all previously downloaded scripts invalid.</p
   >
+  <p class="auth-token-row" [ngSwitch]="authToken() != null">
+    <ng-container *ngSwitchCase="false">
+      <span>No auth token generated.</span>
+      <button mat-button (click)="regenerateToken()"><mat-icon>autorenew</mat-icon> Generate token</button>
+    </ng-container>
+    <ng-container *ngSwitchCase="true">
+      <span>Auth token generated on {{ authToken().createdAt * 1000 | date : 'short' }}</span>
+      <button mat-button (click)="regenerateToken()"><mat-icon>autorenew</mat-icon> Regenerate token</button>
+    </ng-container>
+  </p>
   <div class="table-wrapper mat-elevation-z8">
     <mat-table [dataSource]="keybinds" cdkDropList [cdkDropListData]="keybinds" (cdkDropListDropped)="onDrop($event)">
       <ng-container matColumnDef="dragDrop">

--- a/frontend/src/app/keybind-generator/keybind-generator.component.scss
+++ b/frontend/src/app/keybind-generator/keybind-generator.component.scss
@@ -35,6 +35,12 @@ mat-toolbar {
   }
 }
 
+.auth-token-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .table-wrapper {
   margin-bottom: 16px;
   overflow-x: auto;

--- a/frontend/src/app/keybind-generator/keybind-generator.component.scss
+++ b/frontend/src/app/keybind-generator/keybind-generator.component.scss
@@ -3,6 +3,7 @@
 .max-width {
   max-width: 1200px;
   margin: 0 auto;
+  padding: 0 16px;
   width: 100%;
 }
 
@@ -28,11 +29,7 @@ mat-toolbar {
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  margin: 0 16px;
-
-  button {
-    margin-bottom: 8px;
-  }
+  gap: 8px;
 }
 
 .auth-token-row {

--- a/frontend/src/app/keybind-generator/keybind-generator.component.ts
+++ b/frontend/src/app/keybind-generator/keybind-generator.component.ts
@@ -105,7 +105,7 @@ export class KeybindGeneratorComponent {
       next: newToken => this.authToken.set(newToken),
       error: error => {
         console.error(error);
-        this.snackBar.open('Failed to generate new auth token.', 'Damn');
+        this.snackBar.open('Failed to generate new auth token.', 'Damn', { duration: undefined });
       },
     });
   }

--- a/frontend/src/app/keybind-generator/keybind-generator.component.ts
+++ b/frontend/src/app/keybind-generator/keybind-generator.component.ts
@@ -91,7 +91,7 @@ export class KeybindGeneratorComponent {
   }
 
   generateAutohotkey() {
-    this.apiService.getAuthToken().subscribe({
+    this.apiService.generateAuthToken().subscribe({
       next: authtoken => {
         const script = this.generateAutohotkeyScript(authtoken, this.keybinds);
         this.downloadText(script, 'soundboard.ahk');

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -70,7 +70,11 @@ export class ApiService {
     return this.http.post('/api/auth/logout', {}, { responseType: 'text' }).pipe(tap(() => this.user.set(null)));
   }
 
+  generateAuthToken() {
+    return this.http.post('/api/auth/token', {}, { responseType: 'text' });
+  }
+
   getAuthToken() {
-    return this.http.post('/api/auth/gettoken', {}, { responseType: 'text' });
+    return this.http.get('/api/auth/token', { responseType: 'text' });
   }
 }

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -35,6 +35,11 @@ export interface RandomInfix {
   displayName: string;
 }
 
+export interface AuthToken {
+  token: string;
+  createdAt: number;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -71,10 +76,10 @@ export class ApiService {
   }
 
   generateAuthToken() {
-    return this.http.post('/api/auth/token', {}, { responseType: 'text' });
+    return this.http.post<AuthToken>('/api/auth/token', {});
   }
 
   getAuthToken() {
-    return this.http.get('/api/auth/token', { responseType: 'text' });
+    return this.http.get<AuthToken>('/api/auth/token');
   }
 }

--- a/frontend/src/app/services/sounds.service.ts
+++ b/frontend/src/app/services/sounds.service.ts
@@ -11,7 +11,7 @@ interface ApiSound {
   category: string;
   createdAt: number;
   volumeAdjustment?: number;
-  soundfile?: Readonly<SoundFile>;
+  soundFile?: Readonly<SoundFile>;
 }
 
 export interface SoundFile {
@@ -28,7 +28,7 @@ export class Sound implements ApiSound {
   category: string;
   createdAt: number;
   volumeAdjustment?: number;
-  soundfile?: Readonly<SoundFile>;
+  soundFile?: Readonly<SoundFile>;
 
   constructor(base: ApiSound) {
     this.id = base.id;
@@ -37,7 +37,7 @@ export class Sound implements ApiSound {
     this.category = base.category;
     this.createdAt = base.createdAt;
     this.volumeAdjustment = base.volumeAdjustment;
-    this.soundfile = base.soundfile;
+    this.soundFile = base.soundFile;
   }
 
   getDownloadUrl() {

--- a/frontend/src/app/settings/sound-manager/sound-details/sound-details.component.html
+++ b/frontend/src/app/settings/sound-manager/sound-details/sound-details.component.html
@@ -2,7 +2,7 @@
   <mat-expansion-panel-header>
     <mat-panel-title>
       {{ sound().name }}{{ soundEntry.hasChanges() ? '*' : '' }}
-      <mat-icon *ngIf="sound().soundfile == null" matTooltip="No sound file uploaded. Click the upload button below."
+      <mat-icon *ngIf="sound().soundFile == null" matTooltip="No sound file uploaded. Click the upload button below."
         >error_outline</mat-icon
       >
     </mat-panel-title>
@@ -53,25 +53,25 @@
           <div>Created</div>
           <div timeago [date]="sound().createdAt * 1000" [matTooltip]="sound().createdAt * 1000 | date : 'medium'"></div>
         </div>
-        <ng-container *ngIf="sound().soundfile != null; else noFile">
+        <ng-container *ngIf="sound().soundFile != null; else noFile">
           <div>
             <div>Max Volume</div>
-            <div>{{ sound().soundfile.maxVolume | number : '1.1-1' }} dB</div>
+            <div>{{ sound().soundFile.maxVolume | number : '1.1-1' }} dB</div>
           </div>
           <div>
             <div>Mean Volume</div>
-            <div>{{ sound().soundfile.meanVolume | number : '1.1-1' }} dB</div>
+            <div>{{ sound().soundFile.meanVolume | number : '1.1-1' }} dB</div>
           </div>
           <div>
             <div>Length</div>
-            <div>{{ sound().soundfile.length | number : '1.3-3' }} s</div>
+            <div>{{ sound().soundFile.length | number : '1.3-3' }} s</div>
           </div>
           <div>
             <div>Uploaded</div>
             <div
               timeago
-              [date]="sound().soundfile.uploadedAt * 1000"
-              [matTooltip]="sound().soundfile.uploadedAt * 1000 | date : 'medium'"
+              [date]="sound().soundFile.uploadedAt * 1000"
+              [matTooltip]="sound().soundFile.uploadedAt * 1000 | date : 'medium'"
             ></div>
           </div>
         </ng-container>
@@ -89,7 +89,7 @@
     </button>
     <div class="spinner-button-container">
       <button mat-stroked-button [disabled]="isBusy" (click)="!isBusy && fileImport.click()"
-        ><mat-icon>file_upload</mat-icon> {{ sound().soundfile == null ? 'Upload' : 'Replace' }} sound</button
+        ><mat-icon>file_upload</mat-icon> {{ sound().soundFile == null ? 'Upload' : 'Replace' }} sound</button
       >
       <div class="spinner-container" *ngIf="isBusy">
         <mat-spinner diameter="24"></mat-spinner>

--- a/frontend/src/app/settings/sound-manager/sound-manager.component.ts
+++ b/frontend/src/app/settings/sound-manager/sound-manager.component.ts
@@ -139,7 +139,7 @@ export class SoundManagerComponent {
               mergeMap(sound =>
                 this.soundsService
                   .uploadSound(sound, file)
-                  .pipe(map(soundfile => new SoundEntry(this.soundsService, new Sound({ ...sound, soundfile }))))
+                  .pipe(map(soundFile => new SoundEntry(this.soundsService, new Sound({ ...sound, soundFile }))))
               )
             );
         }, 5),
@@ -231,7 +231,7 @@ export class SoundEntry {
   }
 
   replaceSoundFile(soundFile: SoundFile) {
-    this.sound.mutate(sound => (sound.soundfile = soundFile));
-    this.internalSound.mutate(internalSound => (internalSound.soundfile = soundFile));
+    this.sound.mutate(sound => (sound.soundFile = soundFile));
+    this.internalSound.mutate(internalSound => (internalSound.soundFile = soundFile));
   }
 }

--- a/frontend/src/app/soundboard/soundboard.component.ts
+++ b/frontend/src/app/soundboard/soundboard.component.ts
@@ -85,8 +85,8 @@ export class SoundboardComponent {
       next: () => {
         if (this.settings.debug()) {
           let volString =
-            sound.soundfile != null
-              ? `Volume: Max ${sound.soundfile.maxVolume.toFixed(1)} dB, Average ${sound.soundfile.meanVolume.toFixed(1)} dB, `
+            sound.soundFile != null
+              ? `Volume: Max ${sound.soundFile.maxVolume.toFixed(1)} dB, Average ${sound.soundFile.meanVolume.toFixed(1)} dB, `
               : '';
           volString += sound.volumeAdjustment != null ? `Manual adjustment ${sound.volumeAdjustment} dB` : 'Automatic adjustment';
           this.snackBar.open(volString, 'Ok');


### PR DESCRIPTION
Closes #9.

- Before, auth tokens expired after a week. After this change, they are valid until they are explicitly regenerated.
- Furthermore, the frontend should reuse auth tokens whenever possible and only regenerate them when the user explicitly requests it.